### PR TITLE
Add compatibility fixes between Django v1.8 and v1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - TOX_ENV=py27-django1.8
     - TOX_ENV=py34-django1.7
     - TOX_ENV=py34-django1.8
+    - TOX_ENV=py34-django1.9
 
 install:
   - pip install tox coverage coveralls

--- a/klingon/compat.py
+++ b/klingon/compat.py
@@ -1,20 +1,24 @@
 from __future__ import print_function, unicode_literals, with_statement, division
 from django import VERSION
 
+version = VERSION[1]
 
-V18 = VERSION[1] == 8
-V19 = VERSION[1] == 9
+V15 = 5
+V16 = 6
+V17 = 7
+V18 = 8
+V19 = 9
 
-if V18:
+
+if version in [V15, V16]:
     from django.db.models.loading import get_model
-    from django.contrib.contenttypes.generic import GenericForeignKey
-    from django.contrib.contenttypes.generic import GenericTabularInline
-elif V19:
+    from django.contrib.contenttypes.generic import GenericForeignKey, GenericTabularInline
+
+if version in [V17, V18, V19]:
     from django.apps.registry import apps
     from django.contrib.contenttypes.fields import GenericForeignKey
     from django.contrib.contenttypes.admin import GenericTabularInline
-
     get_model = apps.get_model
 
 
-__all__ = ['get_model', 'GenericForeignKey', GenericTabularInline]
+__all__ = ['get_model', 'GenericForeignKey', 'GenericTabularInline']

--- a/klingon/compat.py
+++ b/klingon/compat.py
@@ -1,0 +1,20 @@
+from __future__ import print_function, unicode_literals, with_statement, division
+from django import VERSION
+
+
+V18 = VERSION[1] == 8
+V19 = VERSION[1] == 9
+
+if V18:
+    from django.db.models.loading import get_model
+    from django.contrib.contenttypes.generic import GenericForeignKey
+    from django.contrib.contenttypes.generic import GenericTabularInline
+elif V19:
+    from django.apps.registry import apps
+    from django.contrib.contenttypes.fields import GenericForeignKey
+    from django.contrib.contenttypes.admin import GenericTabularInline
+
+    get_model = apps.get_model
+
+
+__all__ = ['get_model', 'GenericForeignKey', GenericTabularInline]

--- a/klingon/management/commands/translatemodels.py
+++ b/klingon/management/commands/translatemodels.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models.loading import get_model
+from klingon.compat import get_model
 
 
 class Command(BaseCommand):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,6 @@ coverage
 coveralls
 flake8>=2.1.0
 tox>=2.1.1
-django
 django-autoslug>=1.7.2
 pytest
 pytest-django

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,7 @@ coverage
 coveralls
 flake8>=2.1.0
 tox>=2.1.1
+django
 django-autoslug>=1.7.2
 pytest
 pytest-django

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,10 @@
 import datetime
-
 from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.text import slugify
 from klingon.models import CanNotTranslate, Translation
-
 from .testapp.models import Book, Library
 
 
@@ -72,14 +70,14 @@ class TranslationAPITestCase(TestCase):
 
         self.assertEquals(
             Translation.objects.count(),
-            len(settings.LANGUAGES*len(self.book.translatable_fields)),
+            len(settings.LANGUAGES * len(self.book.translatable_fields)),
         )
         # nothing should happen if you run translate tiwce
         self.book.translate()
 
         self.assertEquals(
             len(Translation.objects.all()),
-            len(settings.LANGUAGES*len(self.book.translatable_fields)),
+            len(settings.LANGUAGES * len(self.book.translatable_fields)),
         )
 
     def test_set_translation(self):
@@ -132,13 +130,13 @@ class TranslationAPITestCase(TestCase):
 
         self.assertEquals(
             len(Translation.objects.all()),
-            (len(settings.LANGUAGES)-1)*len(self.book.translatable_fields)
+            (len(settings.LANGUAGES) - 1) * len(self.book.translatable_fields)
         )
         # nothing should happen if you run translate tiwce
         self.book.translate()
         self.assertEquals(
             len(Translation.objects.all()),
-            (len(settings.LANGUAGES)-1)*len(self.book.translatable_fields),
+            (len(settings.LANGUAGES) - 1) * len(self.book.translatable_fields),
         )
 
     @override_settings(KLINGON_DEFAULT_LANGUAGE='en')
@@ -190,7 +188,7 @@ class AutomaticTranslationAPITestCase(TestCase):
     def test_translation_created_automatically(self):
         self.assertEquals(
             len(Translation.objects.all()),
-            len(settings.LANGUAGES*len(self.library.translatable_fields)),
+            len(settings.LANGUAGES * len(self.library.translatable_fields)),
         )
 
     def test_translation_slug(self):
@@ -198,6 +196,6 @@ class AutomaticTranslationAPITestCase(TestCase):
         self.library.set_translation('es', 'description', self.es_description)
         self.assertEquals(self.library.slug, slugify(self.library.name))
         self.assertEquals(self.library.get_translation('es', 'name'),
-                self.es_name)
+                          self.es_name)
         self.assertEquals(self.library.get_translation('es', 'slug'),
-                self.es_slug)
+                          self.es_slug)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -23,7 +23,6 @@ class CommandsTestCase(TestCase):
         self.es_description = 'El Cuervo es un poema narrativo'
         self.es_slug = slugify(self.es_title)
 
-
     def tearDown(self):
         # Remove cache after each test
         cache.clear()
@@ -42,7 +41,7 @@ class CommandsTestCase(TestCase):
 
         self.assertEquals(
             Translation.objects.count(),
-            len(settings.LANGUAGES*(len(self.book.translatable_fields)+ifslug)),
+            len(settings.LANGUAGES * (len(self.book.translatable_fields) + ifslug)),
         )
 
     def test_translate_models_command_empty(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = {py27,py34}-django{1.8,1.7},py27-django{1.6,1.5}
+envlist = {py27,py34}-django{1.9,1.8,1.7},py27-django{1.6,1.5}
 
 [testenv]
 commands = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = {py27,py34}-django{1.9,1.8,1.7},py27-django{1.6,1.5}
+envlist = {py27,py35}-django{1.9,1.8,1.7},py27-django{1.6,1.5}
 
 [testenv]
 commands = 
@@ -9,6 +9,7 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps = 
     -r{toxinidir}/requirements-test.txt
+    django1.9: Django<1.10
     django1.8: Django<1.9
     django1.7: Django<1.8
     django1.6: Django<1.7


### PR DESCRIPTION
Added `compat.py` to support Django v1.8 and v1.9 related imports for `GenericForeignKey`, `GenericTabularInline` and `get_model`. Also made changes related to code formatting for flake8.

Please review and give feedback if these changes useful.

