### PR TITLE
Add possibility to get widget by field name

### DIFF
--- a/klingon/admin.py
+++ b/klingon/admin.py
@@ -40,8 +40,9 @@ class TranslationInlineForm(ModelForm):
         if self.widgets and self.instance and hasattr(self.instance, 'content_type'):
             model = self.instance.content_type.model_class()
             field = model._meta.get_field(self.instance.field)
-            # get widget for field if any
-            widget = self.widgets.get(field.get_internal_type())
+            # get widget for field if any - by name or by type
+            widget = self.widgets.get(field.name) or \
+                self.widgets.get(field.get_internal_type())
 
             if widget:
                 translation = self.fields['translation']


### PR DESCRIPTION
With this little change is possible to set widget for exact field (by field name).

eg.

```
widgets = {
        'content': MyRichTextEditor(),
        'CharField': forms.TextInput(attrs={'class': 'klingon-char-field'}),
        'TextField': forms.Textarea(attrs={'class': 'klingon-text-field'}),
    }
```