### PR TITLE
Revival/coverage and bugs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,9 +57,13 @@ jobs:
         run: |
           coverage run --source klingon runtests.py --fast --create-db
 
+      - name: Check coverage threshold
+        if: matrix.python-version == '3.13' && matrix.django-version == '5.2'
+        run: coverage report
+
       - name: Generate coverage XML
         if: matrix.python-version == '3.13' && matrix.django-version == '5.2'
-        run: coverage xml
+        run: coverage xml --fail-under=0
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13' && matrix.django-version == '5.2'

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/*
 .ruff_cache/
 coverage.xml
 REVIVAL_PLAN.md
+uv.lock

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,7 +25,9 @@
   regeneration — the explicitly-set value now wins.
 * Translation cache keys are now app-qualified (`app_label.model` instead of
   the bare class name), so identically-named models in different apps can no
-  longer collide. Existing cache entries are invalidated once on upgrade.
+  longer collide. This changes the cache key format; pre-upgrade entries are
+  simply never read again under the new keys and age out via the cache
+  backend's normal eviction — no explicit flush is performed.
 * `translate()` and `set_translation()` on an unsaved instance now raise
   `CanNotTranslate` with a clear message instead of a database
   `IntegrityError`.

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ test-all:
 
 coverage:
 	coverage run --source klingon runtests.py --fast --create-db
-	coverage report -m
-	coverage html
-	open htmlcov/index.html
+	-coverage report -m
+	-coverage html
+	-open htmlcov/index.html
 
 docs:
 	$(MAKE) -C docs clean

--- a/klingon/models.py
+++ b/klingon/models.py
@@ -57,7 +57,7 @@ class Translatable:
         already listed). Computed instead of mutating translatable_fields,
         so class and instance state never diverge.
         """
-        fields = self.translatable_fields
+        fields = tuple(self.translatable_fields)
         if self.translatable_slug is not None \
                 and self.translatable_slug not in fields:
             fields += (self.translatable_slug,)
@@ -70,11 +70,7 @@ class Translatable:
         @rtype: list of Translation objects
         @return: Returns a list of translations objects
         """
-        if self.pk is None:
-            raise CanNotTranslate(
-                _('Save the instance before creating translations: '
-                  'translations are linked to the object primary key')
-            )
+        self._assert_saved()
         translations = []
         for lang in settings.LANGUAGES:
             # do not create an translations for default language.
@@ -121,6 +117,12 @@ class Translatable:
         @rtype: python Dictionary
         @return: Returns a all fieldname / translations (key / value)
         """
+        if self.pk is None:
+            return {
+                field: self.get_translation(lang, field)
+                for field in self._all_translatable_fields()
+            }
+
         key = self._get_translations_cache_key(lang)
         trans_dict = cache.get(key, {})
 
@@ -157,6 +159,7 @@ class Translatable:
             )
         except Translation.DoesNotExist:
             if create:
+                self._assert_saved()
                 trans = Translation.objects.create(
                     object_id=self.pk,
                     content_type=ContentType.objects.get_for_model(self),
@@ -179,6 +182,9 @@ class Translatable:
         @rtype: string
         @return: Returns a translation string
         """
+        if self.pk is None:
+            return getattr(self, field, '')
+
         # Read from cache
         key = self._get_translation_cache_key(lang, field)
         trans = cache.get(key, '')
@@ -216,11 +222,7 @@ class Translatable:
                   'Use the model fields for translations in default language')
             )
 
-        if self.pk is None:
-            raise CanNotTranslate(
-                _('Save the instance before creating translations: '
-                  'translations are linked to the object primary key')
-            )
+        self._assert_saved()
 
         # Get translation, if it does not exits create one
         trans_obj = self.get_translation_obj(lang, field, create=True)
@@ -231,18 +233,19 @@ class Translatable:
         key = self._get_translation_cache_key(lang, field)
         cache.set(key, text)
 
-        # check if the field has an autoslugfield and create the translation.
-        # An explicit translation of the slug field itself must win, so the
-        # slug is only regenerated when some other field was translated.
-        if INSTALLED_AUTOSLUG and field != self.translatable_slug:
-            if self.translatable_slug:
-                try:
-                    slug_field = self._meta.get_field(self.translatable_slug)
-                    auto_slug_obj = slug_field.title_field
-                except AttributeError:
-                    pass
+        # check if the field has an autoslugfield and, if the field just
+        # translated is the slug's *source* field, regenerate the slug
+        # translation from it. An explicit translation of the slug field
+        # itself is never overwritten, because only the source field
+        # triggers regeneration.
+        if INSTALLED_AUTOSLUG and self.translatable_slug:
+            try:
+                slug_field = self._meta.get_field(self.translatable_slug)
+                auto_slug_obj = slug_field.title_field
+            except AttributeError:
+                pass
 
-        if auto_slug_obj:
+        if auto_slug_obj and field == auto_slug_obj:
             tobj = self.get_translation_obj(lang, self.translatable_slug, create=True)
             translation = self.get_translation(lang, auto_slug_obj)
             tobj.translation = slugify(translation)
@@ -268,7 +271,7 @@ class Translatable:
         )
 
         object_type = ContentType.objects.get_for_model(self)
-        link += f'?content_type__id__exact={object_type.id}&object_id={self.id}'
+        link += f'?content_type__id__exact={object_type.id}&object_id={self.pk}'
         return format_html('<a href="{}">translate</a>', link)
 
     translations_link.short_description = 'Translations'
@@ -280,13 +283,24 @@ class Translatable:
         """
         return getattr(settings, 'KLINGON_DEFAULT_LANGUAGE', '')
 
+    def _assert_saved(self):
+        """
+        Raise CanNotTranslate if this instance has not been saved yet;
+        translations are linked to the object's primary key.
+        """
+        if self.pk is None:
+            raise CanNotTranslate(
+                _('Save the instance before creating translations: '
+                  'translations are linked to the object primary key')
+            )
+
     def _get_translations_cache_key(self, lang):
         # label_lower is app-qualified, so equally-named models in
         # different apps can not collide on cache keys
         return f'{self._meta.label_lower}:{self.pk}:{lang}'
 
     def _get_translation_cache_key(self, lang, field):
-        return f'{self._meta.label_lower}:{self.pk}:{lang}:{field}'
+        return f'{self._get_translations_cache_key(lang)}:{field}'
 
 
 class AutomaticTranslation(Translatable):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+import datetime
+
+import pytest
+from django.core.cache import cache
+
+
 def pytest_configure():
     from django.conf import settings
     if not settings.configured:
@@ -9,3 +15,49 @@ def pytest_configure():
             django.setup()
         except AttributeError:
             pass
+
+
+@pytest.fixture(scope='function')
+def book(db):
+    """Standard Book instance with test data for isolation testing.
+
+    Provides a clean Book instance for each test function with:
+    - title="The Raven"
+    - description="The Raven is a narrative poem"
+    - publication_date=1845-01-01
+    - slug="the-raven"
+    """
+    from tests.testapp.models import Book
+    return Book.objects.create(
+        title="The Raven",
+        description="The Raven is a narrative poem",
+        publication_date=datetime.date(1845, 1, 1),
+        slug="the-raven"
+    )
+
+
+@pytest.fixture(scope='function')
+def library(db):
+    """Standard Library instance for isolation testing.
+
+    Provides a clean Library instance for each test function with:
+    - name="Independent"
+    - description="All in ebooks"
+    """
+    from tests.testapp.models import Library
+    return Library.objects.create(
+        name="Independent",
+        description="All in ebooks",
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Auto-clear Django cache after each test.
+
+    Ensures cache state doesn't leak between tests. This fixture runs
+    automatically (autouse=True) after every test, yielding first and
+    then clearing the cache for cleanup.
+    """
+    yield
+    cache.clear()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,10 +1,8 @@
-import datetime
 
+import pytest
 from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-from django.test import TestCase
 
 from klingon.admin import TranslationInlineForm, create_translations
 from klingon.models import Translation
@@ -12,146 +10,138 @@ from klingon.models import Translation
 from .testapp.models import Book
 
 
-class CreateTranslationsActionTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-
-    def tearDown(self):
-        cache.clear()
-
-    def test_create_translations_action_creates_translations(self):
-        self.assertEqual(Translation.objects.count(), 0)
-
-        create_translations(None, None, Book.objects.all())
-
-        # translatable_fields plus the translatable_slug, for every language
-        fields_count = len(self.book.translatable_fields) + 1
-        self.assertEqual(
-            Translation.objects.count(),
-            len(settings.LANGUAGES) * fields_count,
-        )
+# Helper functions for test_admin.py
+def get_translation(book, field, lang='es'):
+    """Helper: fetch a Translation object by field and language."""
+    content_type = ContentType.objects.get_for_model(Book)
+    return Translation.objects.get(
+        content_type=content_type,
+        object_id=book.pk,
+        lang=lang,
+        field=field,
+    )
 
 
-class TranslationInlineFormTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-        self.book.translate()
-        self.content_type = ContentType.objects.get_for_model(Book)
-
-    def tearDown(self):
-        cache.clear()
-
-    def _get_translation(self, field):
-        return Translation.objects.get(
-            content_type=self.content_type,
-            object_id=self.book.pk,
-            lang='es',
-            field=field,
-        )
-
-    def test_widget_swapped_to_text_input_for_char_field(self):
-        trans = self._get_translation('title')
-        form = TranslationInlineForm(instance=trans)
-        self.assertIsInstance(form.fields['translation'].widget, forms.TextInput)
-
-    def test_widget_swapped_to_textarea_for_text_field(self):
-        trans = self._get_translation('description')
-        form = TranslationInlineForm(instance=trans)
-        self.assertIsInstance(form.fields['translation'].widget, forms.Textarea)
-
-    def test_widget_not_swapped_for_slug_field(self):
-        # SlugField is neither keyed by name nor by internal type in the
-        # widgets mapping, so it keeps the ModelForm default: since
-        # Translation.translation is a TextField, that default is Textarea.
-        trans = self._get_translation('slug')
-        form = TranslationInlineForm(instance=trans)
-        self.assertIs(type(form.fields['translation'].widget), forms.Textarea)
-
-    def test_init_without_instance_content_type_does_not_raise(self):
-        form = TranslationInlineForm()
-        self.assertIsInstance(form.fields['translation'].widget, forms.Textarea)
+def data_for_translation_form(trans, translation):
+    """Helper: build form data dict for TranslationInlineForm."""
+    content_type = ContentType.objects.get_for_model(Book)
+    return {
+        'content_type': content_type.pk,
+        'object_id': trans.object_id,
+        'lang': trans.lang,
+        'field': trans.field,
+        'translation': translation,
+    }
 
 
-class TranslationInlineFormCleanTranslationTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-        self.book.translate()
-        self.content_type = ContentType.objects.get_for_model(Book)
+# Fixtures
+@pytest.fixture
+def book_with_translations(book, db):
+    """Book with translations already created via book.translate()."""
+    book.translate()
+    return book
 
-    def tearDown(self):
-        cache.clear()
 
-    def _get_translation(self, field):
-        return Translation.objects.get(
-            content_type=self.content_type,
-            object_id=self.book.pk,
-            lang='es',
-            field=field,
-        )
+# Tests: CreateTranslationsActionTestCase
+@pytest.mark.django_db
+def test_create_translations_action_creates_translations(book):
+    """Test create_translations admin action creates translations for all languages."""
+    assert Translation.objects.count() == 0
 
-    def _data_for(self, trans, translation):
-        return {
-            'content_type': self.content_type.pk,
-            'object_id': trans.object_id,
-            'lang': trans.lang,
-            'field': trans.field,
-            'translation': translation,
-        }
+    create_translations(None, None, Book.objects.all())
 
-    def test_translation_longer_than_max_length_is_invalid(self):
-        trans = self._get_translation('title')
-        data = self._data_for(trans, 'x' * 101)  # title max_length is 100
+    # translatable_fields plus the translatable_slug, for every language
+    fields_count = len(book.translatable_fields) + 1
+    assert Translation.objects.count() == len(settings.LANGUAGES) * fields_count
 
-        form = TranslationInlineForm(data=data, instance=trans)
 
-        self.assertFalse(form.is_valid())
-        self.assertIn('translation', form.errors)
-        self.assertIn('too long', form.errors['translation'][0])
+# Tests: TranslationInlineFormTestCase
+@pytest.mark.django_db
+def test_widget_swapped_to_text_input_for_char_field(book_with_translations):
+    """Test that TextInput widget is used for CharField translations."""
+    trans = get_translation(book_with_translations, 'title')
+    form = TranslationInlineForm(instance=trans)
+    assert isinstance(form.fields['translation'].widget, forms.TextInput)
 
-    def test_translation_within_max_length_is_valid(self):
-        trans = self._get_translation('title')
-        data = self._data_for(trans, 'A short title')
 
-        form = TranslationInlineForm(data=data, instance=trans)
+@pytest.mark.django_db
+def test_widget_swapped_to_textarea_for_text_field(book_with_translations):
+    """Test that Textarea widget is used for TextField translations."""
+    trans = get_translation(book_with_translations, 'description')
+    form = TranslationInlineForm(instance=trans)
+    assert isinstance(form.fields['translation'].widget, forms.Textarea)
 
-        self.assertTrue(form.is_valid())
 
-    def test_translation_length_check_skipped_when_no_max_length(self):
-        trans = self._get_translation('description')
-        data = self._data_for(trans, 'x' * 10000)  # TextField has no max_length
+@pytest.mark.django_db
+def test_widget_not_swapped_for_slug_field(book_with_translations):
+    """Test that SlugField translations keep default Textarea widget.
 
-        form = TranslationInlineForm(data=data, instance=trans)
+    SlugField is neither keyed by name nor by internal type in the
+    widgets mapping, so it keeps the ModelForm default: since
+    Translation.translation is a TextField, that default is Textarea.
+    """
+    trans = get_translation(book_with_translations, 'slug')
+    form = TranslationInlineForm(instance=trans)
+    assert type(form.fields['translation'].widget) is forms.Textarea
 
-        self.assertTrue(form.is_valid())
 
-    def test_translation_without_content_object_is_invalid(self):
-        orphan = Translation(
-            content_type=self.content_type,
-            object_id=99999,
-            lang='es',
-            field='title',
-        )
-        data = self._data_for(orphan, 'Some translation')
+@pytest.mark.django_db
+def test_init_without_instance_content_type_does_not_raise():
+    """Test that TranslationInlineForm initializes without an instance."""
+    form = TranslationInlineForm()
+    assert isinstance(form.fields['translation'].widget, forms.Textarea)
 
-        form = TranslationInlineForm(data=data, instance=orphan)
 
-        self.assertFalse(form.is_valid())
-        self.assertIn('translation', form.errors)
-        self.assertIn(
-            'First create all translation', form.errors['translation'][0]
-        )
+# Tests: TranslationInlineFormCleanTranslationTestCase
+@pytest.mark.django_db
+def test_translation_longer_than_max_length_is_invalid(book_with_translations):
+    """Test that translations exceeding max_length are rejected."""
+    trans = get_translation(book_with_translations, 'title')
+    data = data_for_translation_form(trans, 'x' * 101)  # title max_length is 100
+
+    form = TranslationInlineForm(data=data, instance=trans)
+
+    assert not form.is_valid()
+    assert 'translation' in form.errors
+    assert 'too long' in form.errors['translation'][0]
+
+
+@pytest.mark.django_db
+def test_translation_within_max_length_is_valid(book_with_translations):
+    """Test that translations within max_length are accepted."""
+    trans = get_translation(book_with_translations, 'title')
+    data = data_for_translation_form(trans, 'A short title')
+
+    form = TranslationInlineForm(data=data, instance=trans)
+
+    assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_translation_length_check_skipped_when_no_max_length(book_with_translations):
+    """Test that TextField translations skip max_length validation."""
+    trans = get_translation(book_with_translations, 'description')
+    data = data_for_translation_form(trans, 'x' * 10000)  # TextField has no max_length
+
+    form = TranslationInlineForm(data=data, instance=trans)
+
+    assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_translation_without_content_object_is_invalid(book_with_translations):
+    """Test that orphaned translations (object_id doesn't exist) are rejected."""
+    content_type = ContentType.objects.get_for_model(Book)
+    orphan = Translation(
+        content_type=content_type,
+        object_id=99999,
+        lang='es',
+        field='title',
+    )
+    data = data_for_translation_form(orphan, 'Some translation')
+
+    form = TranslationInlineForm(data=data, instance=orphan)
+
+    assert not form.is_valid()
+    assert 'translation' in form.errors
+    assert 'First create all translation' in form.errors['translation'][0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,218 +1,201 @@
-import datetime
-
+import pytest
 from django.conf import settings
-from django.core.cache import cache
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.text import slugify
 
 from klingon.models import CanNotTranslate, Translation
 
-from .testapp.models import Book, Library
+from .testapp.models import Library
+
+# ============================================================================
+# TranslationAPITestCase tests (migrated to pytest functions)
+# ============================================================================
 
 
-class TranslationAPITestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven"
-        )
-        self.es_title = "El Cuervo"
-        self.es_description = 'El Cuervo es un poema narrativo'
-        self.es_slug = slugify(self.es_title)
-
-    def tearDown(self):
-        # Remove cache after each test
-        cache.clear()
-
-    def test_api_general_usage(self):
-        # translate book to spanish
-        self.book.set_translation('es', 'title', self.es_title)
-        self.book.set_translation('es', 'description', self.es_description)
-        self.book.set_translation('es', 'slug', self.es_slug)
-        # Get translations
-        self.assertEqual(
-            self.book.get_translation('es', 'title'),
-            self.es_title
-        )
-        self.assertEqual(
-            self.book.get_translation('es', 'description'),
-            self.es_description,
-        )
-        self.assertEqual(
-            self.book.get_translation('es', 'slug'),
-            self.es_slug,
-        )
-        self.assertEqual(
-            self.book.translations('es'),
-            {
-                'title': self.es_title,
-                'description': self.es_description,
-                'slug': self.es_slug,
-            }
-        )
-
-    def test_api_default_value(self):
-        self.assertEqual(
-            self.book.get_translation('es', 'title'),
-            self.book.title
-        )
-        self.assertEqual(
-            self.book.get_translation('es', 'description'),
-            self.book.description
-        )
-        self.assertEqual(
-            self.book.get_translation('es', 'slug'),
-            self.book.slug
-        )
-
-    def test_create_translations(self):
-        self.book.translate()
-
-        # translatable_fields plus the translatable_slug
-        fields_count = len(self.book.translatable_fields) + 1
-        self.assertEqual(
-            Translation.objects.count(),
-            len(settings.LANGUAGES) * fields_count,
-        )
-        # nothing should happen if you run translate tiwce
-        self.book.translate()
-
-        self.assertEqual(
-            Translation.objects.count(),
-            len(settings.LANGUAGES) * fields_count,
-        )
-
-    def test_set_translation(self):
-        self.book.set_translation('es', 'title', self.es_title)
-        self.assertEqual(
-            Translation.objects.get(lang='es', field='title').translation,
-            self.es_title
-        )
-
-    def test_get_translation(self):
-        self.book.set_translation('es', 'title', self.es_title)
-        es_title = self.book.get_translation('es', 'title')
-        self.assertEqual(
-            es_title,
-            self.es_title
-        )
-
-    def test_translations(self):
-        # translate book to spanish
-        self.book.set_translation('es', 'title', self.es_title)
-        self.book.set_translation('es', 'description', self.es_description)
-        self.book.set_translation('es', 'slug', self.es_slug)
-        # get all spanish translations for the book
-        self.assertEqual(
-            self.book.translations('es'),
-            {
-                'title': self.es_title,
-                'description': self.es_description,
-                'slug': self.es_slug,
-            }
-        )
-
-    def test_translations_cache(self):
-        # translate book to spanish
-        self.book.set_translation('es', 'title', self.es_title)
-        self.book.set_translation('es', 'description', self.es_description)
-        self.book.set_translation('es', 'slug', self.es_slug)
-        # get translations
-        trans = self.book.translations('es')
-        # set a new translation
-        es_new_title = 'El Cuervo (*)'
-        self.book.set_translation('es', 'title', es_new_title)
-        # get new translations
-        new_trans = self.book.translations('es')
-        self.assertNotEqual(trans, new_trans)
-        self.assertEqual(
-            new_trans,
-            {
-                'title': es_new_title,
-                'description': self.es_description,
-                'slug': self.es_slug,
-            }
-        )
-
-    @override_settings(KLINGON_DEFAULT_LANGUAGE='en')
-    def test_create_translations_with_default_language(self):
-        self.book.translate()
-
-        # translatable_fields plus the translatable_slug
-        fields_count = len(self.book.translatable_fields) + 1
-        self.assertEqual(
-            len(Translation.objects.all()),
-            (len(settings.LANGUAGES) - 1) * fields_count
-        )
-        # nothing should happen if you run translate tiwce
-        self.book.translate()
-        self.assertEqual(
-            len(Translation.objects.all()),
-            (len(settings.LANGUAGES) - 1) * fields_count,
-        )
-
-    @override_settings(KLINGON_DEFAULT_LANGUAGE='en')
-    def test_get_translation_with_default_language(self):
-        es_title = self.book.get_translation('es', 'title')
-        # Get should not create empty translations
-        self.assertEqual(Translation.objects.count(), 0)
-        # Get should fall back to default language
-        self.assertEqual(es_title, self.book.title)
-
-    @override_settings(KLINGON_DEFAULT_LANGUAGE='en')
-    def test_set_translation_with_default_language(self):
-        # Verify that there are no translations
-        self.assertEqual(Translation.objects.count(), 0)
-        # Create a translation
-        self.book.set_translation('es', 'title', self.es_title)
-        # Get should work as expected
-        self.assertEqual(
-            self.es_title,
-            self.book.get_translation('es', 'title')
-        )
-        # Verify that only one translation was created
-        self.assertEqual(Translation.objects.count(), 1)
-
-    @override_settings(KLINGON_DEFAULT_LANGUAGE='en')
-    def test_set_translation_in_default_language(self):
-        # Create a translation for default language
-        self.assertRaises(
-            CanNotTranslate,
-            self.book.set_translation,
-            'en', 'title', 'The Raven!'
-        )
+@pytest.mark.django_db
+def test_api_general_usage(book):
+    """Test basic set/get translation API."""
+    es_title = "El Cuervo"
+    es_description = 'El Cuervo es un poema narrativo'
+    es_slug = slugify(es_title)
+    # translate book to spanish
+    book.set_translation('es', 'title', es_title)
+    book.set_translation('es', 'description', es_description)
+    book.set_translation('es', 'slug', es_slug)
+    # Get translations
+    assert book.get_translation('es', 'title') == es_title
+    assert book.get_translation('es', 'description') == es_description
+    assert book.get_translation('es', 'slug') == es_slug
+    assert book.translations('es') == {
+        'title': es_title,
+        'description': es_description,
+        'slug': es_slug,
+    }
 
 
-class AutomaticTranslationAPITestCase(TestCase):
-    def setUp(self):
-        self.library = Library.objects.create(
-            name="Indepent",
-            description="All in ebooks",
-        )
-        self.es_name = "Independiente"
-        self.es_description = 'Todo en ebooks'
-        self.es_slug = slugify(self.es_name)
+@pytest.mark.django_db
+def test_api_default_value(book):
+    """Test that untranslated fields fall back to default values."""
+    assert book.get_translation('es', 'title') == book.title
+    assert book.get_translation('es', 'description') == book.description
+    assert book.get_translation('es', 'slug') == book.slug
 
-    def tearDown(self):
-        # Remove cache after each test
-        cache.clear()
 
-    def test_translation_created_automatically(self):
-        # translatable_fields plus the translatable_slug
-        fields_count = len(self.library.translatable_fields) + 1
-        self.assertEqual(
-            len(Translation.objects.all()),
-            len(settings.LANGUAGES) * fields_count,
-        )
+@pytest.mark.django_db
+def test_create_translations(book):
+    """Test translate() creates translations for all languages."""
+    book.translate()
 
-    def test_translation_slug(self):
-        self.library.set_translation('es', 'name', self.es_name)
-        self.library.set_translation('es', 'description', self.es_description)
-        self.assertEqual(self.library.slug, slugify(self.library.name))
-        self.assertEqual(self.library.get_translation('es', 'name'),
-                          self.es_name)
-        self.assertEqual(self.library.get_translation('es', 'slug'),
-                          self.es_slug)
+    # translatable_fields plus the translatable_slug
+    fields_count = len(book.translatable_fields) + 1
+    assert Translation.objects.count() == len(settings.LANGUAGES) * fields_count
+
+    # nothing should happen if you run translate twice
+    book.translate()
+
+    assert Translation.objects.count() == len(settings.LANGUAGES) * fields_count
+
+
+@pytest.mark.django_db
+def test_set_translation(book):
+    """Test set_translation creates a Translation object."""
+    es_title = "El Cuervo"
+    book.set_translation('es', 'title', es_title)
+    assert Translation.objects.get(lang='es', field='title').translation == es_title
+
+
+@pytest.mark.django_db
+def test_get_translation(book):
+    """Test get_translation retrieves stored translations."""
+    es_title = "El Cuervo"
+    book.set_translation('es', 'title', es_title)
+    retrieved_title = book.get_translation('es', 'title')
+    assert retrieved_title == es_title
+
+
+@pytest.mark.django_db
+def test_translations(book):
+    """Test translations() returns all translations for a language."""
+    es_title = "El Cuervo"
+    es_description = 'El Cuervo es un poema narrativo'
+    es_slug = slugify(es_title)
+    # translate book to spanish
+    book.set_translation('es', 'title', es_title)
+    book.set_translation('es', 'description', es_description)
+    book.set_translation('es', 'slug', es_slug)
+    # get all spanish translations for the book
+    assert book.translations('es') == {
+        'title': es_title,
+        'description': es_description,
+        'slug': es_slug,
+    }
+
+
+@pytest.mark.django_db
+def test_translations_cache(book):
+    """Test that cache is properly invalidated on translation changes."""
+    es_title = "El Cuervo"
+    es_description = 'El Cuervo es un poema narrativo'
+    es_slug = slugify(es_title)
+    # translate book to spanish
+    book.set_translation('es', 'title', es_title)
+    book.set_translation('es', 'description', es_description)
+    book.set_translation('es', 'slug', es_slug)
+    # get translations
+    trans = book.translations('es')
+    # set a new translation
+    es_new_title = 'El Cuervo (*)'
+    book.set_translation('es', 'title', es_new_title)
+    # get new translations
+    new_trans = book.translations('es')
+    assert trans != new_trans
+    assert new_trans == {
+        'title': es_new_title,
+        'description': es_description,
+        'slug': es_slug,
+    }
+
+
+@pytest.mark.django_db
+@override_settings(KLINGON_DEFAULT_LANGUAGE='en')
+def test_create_translations_with_default_language(book):
+    """Test translate() excludes translations in default language."""
+    book.translate()
+
+    # translatable_fields plus the translatable_slug
+    fields_count = len(book.translatable_fields) + 1
+    expected = (len(settings.LANGUAGES) - 1) * fields_count
+    assert len(Translation.objects.all()) == expected
+
+    # nothing should happen if you run translate twice
+    book.translate()
+    assert len(Translation.objects.all()) == expected
+
+
+@pytest.mark.django_db
+@override_settings(KLINGON_DEFAULT_LANGUAGE='en')
+def test_get_translation_with_default_language(book):
+    """Test get_translation with default language excludes default lang translations."""
+    es_title = book.get_translation('es', 'title')
+    # Get should not create empty translations
+    assert Translation.objects.count() == 0
+    # Get should fall back to default language
+    assert es_title == book.title
+
+
+@pytest.mark.django_db
+@override_settings(KLINGON_DEFAULT_LANGUAGE='en')
+def test_set_translation_with_default_language(book):
+    """Test set_translation with default language excludes default language."""
+    es_title = "El Cuervo"
+    # Verify that there are no translations
+    assert Translation.objects.count() == 0
+    # Create a translation
+    book.set_translation('es', 'title', es_title)
+    # Get should work as expected
+    assert es_title == book.get_translation('es', 'title')
+    # Verify that only one translation was created
+    assert Translation.objects.count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(KLINGON_DEFAULT_LANGUAGE='en')
+def test_set_translation_in_default_language(book):
+    """Test that setting translation in default language raises error."""
+    with pytest.raises(CanNotTranslate):
+        book.set_translation('en', 'title', 'The Raven!')
+
+
+# ============================================================================
+# AutomaticTranslationAPITestCase tests (migrated to pytest functions)
+# ============================================================================
+
+
+@pytest.mark.django_db
+def test_translation_created_automatically(db):
+    """Test that translations are created automatically on save."""
+    library = Library.objects.create(
+        name="Indepent",
+        description="All in ebooks",
+    )
+    # translatable_fields plus the translatable_slug
+    fields_count = len(library.translatable_fields) + 1
+    assert len(Translation.objects.all()) == len(settings.LANGUAGES) * fields_count
+
+
+@pytest.mark.django_db
+def test_translation_slug(db):
+    """Test that slug translation works correctly."""
+    es_name = "Independiente"
+    es_description = 'Todo en ebooks'
+    es_slug = slugify(es_name)
+
+    library = Library.objects.create(
+        name="Indepent",
+        description="All in ebooks",
+    )
+    library.set_translation('es', 'name', es_name)
+    library.set_translation('es', 'description', es_description)
+    assert library.slug == slugify(library.name)
+    assert library.get_translation('es', 'name') == es_name
+    assert library.get_translation('es', 'slug') == es_slug

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,67 +1,44 @@
-import datetime
-
+import pytest
 from django.conf import settings
-from django.core.cache import cache
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase
-from django.utils.text import slugify
 
 from klingon.models import Translation
 
-from .testapp.models import Book
+
+@pytest.mark.django_db
+def test_translate_models_command_success(book):
+    """Test translatemodels command creates translations for specified model."""
+    call_command('translatemodels', 'testapp.Book')
+
+    ifslug = 1 if book.translatable_slug else 0
+
+    assert Translation.objects.count() == len(settings.LANGUAGES) * (
+        len(book.translatable_fields) + ifslug
+    )
 
 
-class CommandsTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-        self.es_title = "El Cuervo"
-        self.es_description = 'El Cuervo es un poema narrativo'
-        self.es_slug = slugify(self.es_title)
+@pytest.mark.django_db
+def test_translate_models_command_empty():
+    """Test translatemodels command with no arguments does nothing."""
+    call_command('translatemodels')
+    assert Translation.objects.count() == 0
 
-    def tearDown(self):
-        # Remove cache after each test
-        cache.clear()
 
-    def _test_translate_models_command(self, args):
-        args = args
-        opts = {}
-        call_command('translatemodels', *args, **opts)
+@pytest.mark.django_db
+def test_translate_models_command_wrong_args():
+    """Test translatemodels command raises CommandError for invalid model."""
+    with pytest.raises(CommandError):
+        call_command('translatemodels', 'wrong.argument')
 
-    def test_translate_models_command_success(self):
-        self._test_translate_models_command(['testapp.Book'])
 
-        ifslug = 0
-        if self.book.translatable_slug:
-            ifslug = 1
+@pytest.mark.django_db
+def test_translate_models_command_not_translatable_model():
+    """Test translatemodels command raises CommandError for non-translatable model.
 
-        self.assertEqual(
-            Translation.objects.count(),
-            len(settings.LANGUAGES * (len(self.book.translatable_fields) + ifslug)),
-        )
-
-    def test_translate_models_command_empty(self):
-        self._test_translate_models_command([])
-        self.assertEqual(Translation.objects.count(), 0)
-
-    def test_translate_models_command_wrong_args(self):
-        self.assertRaises(
-            CommandError,
-            self._test_translate_models_command,
-            ['wrong.argument']
-        )
-
-    def test_translate_models_command_not_translatable_model(self):
-        # ContentType always has rows in a test DB (created by Django's
-        # contenttypes machinery), so the command's loop actually runs and
-        # hits AttributeError when it calls .translate() on a plain model.
-        self.assertRaises(
-            CommandError,
-            self._test_translate_models_command,
-            ['contenttypes.ContentType']
-        )
+    ContentType always has rows in a test DB (created by Django's
+    contenttypes machinery), so the command's loop actually runs and
+    hits AttributeError when it calls .translate() on a plain model.
+    """
+    with pytest.raises(CommandError):
+        call_command('translatemodels', 'contenttypes.ContentType')

--- a/tests/test_models_extra.py
+++ b/tests/test_models_extra.py
@@ -1,9 +1,8 @@
 import datetime
-from unittest import mock
 
+import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
-from django.test import TestCase
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.text import slugify
@@ -13,228 +12,221 @@ from klingon.models import CanNotTranslate, Translatable, Translation
 from .testapp.models import Book, Library
 
 
-class TranslationStrTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-
-    def tearDown(self):
-        cache.clear()
-
-    def test_translation_str(self):
-        self.book.translate()
-
-        trans = Translation.objects.get(lang='es', field='title')
-
-        self.assertEqual(
-            str(trans),
-            f'{self.book} : es : title',
-        )
+@pytest.fixture
+def book(db):
+    """Create a basic Book instance."""
+    return Book.objects.create(
+        title="The Raven",
+        description="The Raven is a narrative poem",
+        publication_date=datetime.date(1845, 1, 1),
+        slug="the-raven",
+    )
 
 
-class TranslationsObjectsTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-
-    def tearDown(self):
-        cache.clear()
-
-    def test_translations_objects_returns_only_that_language(self):
-        self.book.translate()
-
-        es_translations = self.book.translations_objects('es')
-
-        # translatable_fields ('title', 'description') plus the slug
-        self.assertEqual(es_translations.count(), 3)
-        for trans in es_translations:
-            self.assertEqual(trans.lang, 'es')
+@pytest.fixture
+def library(db):
+    """Create a basic Library instance."""
+    return Library.objects.create(
+        name="Indepent",
+        description="All in ebooks",
+    )
 
 
-class TranslationsLinkTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-
-    def tearDown(self):
-        cache.clear()
-
-    def test_translations_link(self):
-        content_type = ContentType.objects.get_for_model(Book)
-
-        expected_url = (
-            reverse('admin:klingon_translation_changelist')
-            + f'?content_type__id__exact={content_type.id}&object_id={self.book.pk}'
-        )
-
-        self.assertEqual(
-            self.book.translations_link(),
-            f'<a href="{escape(expected_url)}">translate</a>',
-        )
+@pytest.fixture
+def book_with_translations(book, db):
+    """Create a book with Spanish translations pre-set."""
+    book.set_translation('es', 'title', 'El Cuervo')
+    book.set_translation('es', 'description', 'El Cuervo es un poema')
+    book.set_translation('es', 'slug', slugify('El Cuervo'))
+    return book
 
 
-class GetTranslationObjTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-
-    def tearDown(self):
-        cache.clear()
-
-    def test_create_true_creates_missing_translation(self):
-        self.assertEqual(Translation.objects.count(), 0)
-
-        trans = self.book.get_translation_obj('es', 'title', create=True)
-
-        self.assertIsNotNone(trans)
-        self.assertIsNone(trans.translation)
-        self.assertEqual(Translation.objects.count(), 1)
-
-    def test_returns_existing_translation(self):
-        self.book.set_translation('es', 'title', 'El Cuervo')
-
-        trans = self.book.get_translation_obj('es', 'title', create=True)
-
-        self.assertEqual(trans.translation, 'El Cuervo')
-
-    def test_create_false_returns_none_when_missing(self):
-        trans = self.book.get_translation_obj('es', 'title', create=False)
-
-        self.assertIsNone(trans)
-        self.assertEqual(Translation.objects.count(), 0)
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear cache after each test."""
+    yield
+    cache.clear()
 
 
-class CacheHitTestCase(TestCase):
-    def setUp(self):
-        self.book = Book.objects.create(
-            title="The Raven",
-            description="The Raven is a narrative poem",
-            publication_date=datetime.date(1845, 1, 1),
-            slug="the-raven",
-        )
-        self.book.set_translation('es', 'title', 'El Cuervo')
-        self.book.set_translation('es', 'description', 'El Cuervo es un poema')
-        self.book.set_translation('es', 'slug', slugify('El Cuervo'))
-
-    def tearDown(self):
-        cache.clear()
-
-    def test_get_translation_second_call_hits_cache(self):
-        self.book.get_translation('es', 'title')
-
-        with self.assertNumQueries(0):
-            self.book.get_translation('es', 'title')
-
-    def test_translations_second_call_hits_cache(self):
-        self.book.translations('es')
-
-        with self.assertNumQueries(0):
-            self.book.translations('es')
+# TranslationStrTestCase
 
 
-class AutoslugDisabledTestCase(TestCase):
-    def setUp(self):
-        self.library = Library.objects.create(
-            name="Indepent",
-            description="All in ebooks",
-        )
+@pytest.mark.django_db
+def test_translation_str(book):
+    book.translate()
 
-    def tearDown(self):
-        cache.clear()
+    trans = Translation.objects.get(lang='es', field='title')
 
-    def test_set_translation_does_not_touch_slug_when_autoslug_disabled(self):
-        with mock.patch('klingon.models.INSTALLED_AUTOSLUG', False):
-            self.library.set_translation('es', 'name', 'Independiente')
-
-        slug_trans = Translation.objects.get(lang='es', field='slug')
-        self.assertFalse(slug_trans.translation)
+    assert str(trans) == f'{book} : es : title'
 
 
-class UnsavedInstanceGuardTestCase(TestCase):
-    def tearDown(self):
-        cache.clear()
-
-    def test_translate_raises_for_unsaved_instance(self):
-        book = Book()
-
-        self.assertRaises(CanNotTranslate, book.translate)
-
-    def test_set_translation_raises_for_unsaved_instance(self):
-        book = Book()
-
-        self.assertRaises(
-            CanNotTranslate,
-            book.set_translation,
-            'es', 'title', 'x',
-        )
-
-    def test_get_translation_obj_create_raises_for_unsaved_instance(self):
-        book = Book()
-
-        self.assertRaises(
-            CanNotTranslate,
-            book.get_translation_obj,
-            'es', 'title', True,
-        )
-
-    def test_get_translation_no_cache_bleed_between_unsaved_instances(self):
-        book_a = Book(title='Alpha')
-        book_b = Book(title='Beta')
-
-        self.assertEqual(book_a.get_translation('es', 'title'), 'Alpha')
-        self.assertEqual(book_b.get_translation('es', 'title'), 'Beta')
-        # calling again (order reversed) must still be instance-specific
-        self.assertEqual(book_b.get_translation('es', 'title'), 'Beta')
-        self.assertEqual(book_a.get_translation('es', 'title'), 'Alpha')
-
-        self.assertEqual(Translation.objects.count(), 0)
-
-    def test_translations_no_cache_bleed_between_unsaved_instances(self):
-        book_a = Book(title='Alpha')
-        book_b = Book(title='Beta')
-
-        self.assertEqual(book_a.translations('es')['title'], 'Alpha')
-        self.assertEqual(book_b.translations('es')['title'], 'Beta')
-
-        self.assertEqual(Translation.objects.count(), 0)
+# TranslationsObjectsTestCase
 
 
-class AllTranslatableFieldsMutationTestCase(TestCase):
+@pytest.mark.django_db
+def test_translations_objects_returns_only_that_language(book):
+    book.translate()
+
+    es_translations = book.translations_objects('es')
+
+    # translatable_fields ('title', 'description') plus the slug
+    assert es_translations.count() == 3
+    for trans in es_translations:
+        assert trans.lang == 'es'
+
+
+# TranslationsLinkTestCase
+
+
+@pytest.mark.django_db
+def test_translations_link(book):
+    content_type = ContentType.objects.get_for_model(Book)
+
+    expected_url = (
+        reverse('admin:klingon_translation_changelist')
+        + f'?content_type__id__exact={content_type.id}&object_id={book.pk}'
+    )
+
+    assert book.translations_link() == f'<a href="{escape(expected_url)}">translate</a>'
+
+
+# GetTranslationObjTestCase
+
+
+@pytest.mark.django_db
+def test_create_true_creates_missing_translation(book):
+    assert Translation.objects.count() == 0
+
+    trans = book.get_translation_obj('es', 'title', create=True)
+
+    assert trans is not None
+    assert trans.translation is None
+    assert Translation.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_returns_existing_translation(book):
+    book.set_translation('es', 'title', 'El Cuervo')
+
+    trans = book.get_translation_obj('es', 'title', create=True)
+
+    assert trans.translation == 'El Cuervo'
+
+
+@pytest.mark.django_db
+def test_create_false_returns_none_when_missing(book):
+    trans = book.get_translation_obj('es', 'title', create=False)
+
+    assert trans is None
+    assert Translation.objects.count() == 0
+
+
+# CacheHitTestCase
+
+
+@pytest.mark.django_db
+def test_get_translation_second_call_hits_cache(
+    book_with_translations, django_assert_num_queries
+):
+    book_with_translations.get_translation('es', 'title')
+
+    with django_assert_num_queries(0):
+        book_with_translations.get_translation('es', 'title')
+
+
+@pytest.mark.django_db
+def test_translations_second_call_hits_cache(
+    book_with_translations, django_assert_num_queries
+):
+    book_with_translations.translations('es')
+
+    with django_assert_num_queries(0):
+        book_with_translations.translations('es')
+
+
+# AutoslugDisabledTestCase
+
+
+@pytest.mark.django_db
+def test_set_translation_does_not_touch_slug_when_autoslug_disabled(
+    library, monkeypatch
+):
+    monkeypatch.setattr('klingon.models.INSTALLED_AUTOSLUG', False)
+    library.set_translation('es', 'name', 'Independiente')
+
+    slug_trans = Translation.objects.get(lang='es', field='slug')
+    assert not slug_trans.translation
+
+
+# UnsavedInstanceGuardTestCase
+
+
+@pytest.mark.django_db
+def test_translate_raises_for_unsaved_instance():
+    book = Book()
+
+    with pytest.raises(CanNotTranslate):
+        book.translate()
+
+
+@pytest.mark.django_db
+def test_set_translation_raises_for_unsaved_instance():
+    book = Book()
+
+    with pytest.raises(CanNotTranslate):
+        book.set_translation('es', 'title', 'x')
+
+
+@pytest.mark.django_db
+def test_get_translation_obj_create_raises_for_unsaved_instance():
+    book = Book()
+
+    with pytest.raises(CanNotTranslate):
+        book.get_translation_obj('es', 'title', True)
+
+
+@pytest.mark.django_db
+def test_get_translation_no_cache_bleed_between_unsaved_instances():
+    book_a = Book(title='Alpha')
+    book_b = Book(title='Beta')
+
+    assert book_a.get_translation('es', 'title') == 'Alpha'
+    assert book_b.get_translation('es', 'title') == 'Beta'
+    # calling again (order reversed) must still be instance-specific
+    assert book_b.get_translation('es', 'title') == 'Beta'
+    assert book_a.get_translation('es', 'title') == 'Alpha'
+
+    assert Translation.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_translations_no_cache_bleed_between_unsaved_instances():
+    book_a = Book(title='Alpha')
+    book_b = Book(title='Beta')
+
+    assert book_a.translations('es')['title'] == 'Alpha'
+    assert book_b.translations('es')['title'] == 'Beta'
+
+    assert Translation.objects.count() == 0
+
+
+# AllTranslatableFieldsMutationTestCase
+
+
+@pytest.mark.django_db
+def test_list_translatable_fields_not_mutated():
     """
     Bug: _all_translatable_fields() aliased a list-typed translatable_fields
     class attribute and mutated it in place via `+=`.
     """
 
-    def tearDown(self):
-        cache.clear()
+    class LocalTranslatable(Translatable):
+        translatable_fields = ['title', 'description']
+        translatable_slug = 'slug'
 
-    def test_list_translatable_fields_not_mutated(self):
-        class LocalTranslatable(Translatable):
-            translatable_fields = ['title', 'description']
-            translatable_slug = 'slug'
+    instance = LocalTranslatable()
 
-        instance = LocalTranslatable()
+    instance._all_translatable_fields()
+    instance._all_translatable_fields()
 
-        instance._all_translatable_fields()
-        instance._all_translatable_fields()
-
-        self.assertEqual(
-            LocalTranslatable.translatable_fields,
-            ['title', 'description'],
-        )
+    assert LocalTranslatable.translatable_fields == ['title', 'description']

--- a/tests/test_models_extra.py
+++ b/tests/test_models_extra.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils.html import escape
 from django.utils.text import slugify
 
-from klingon.models import CanNotTranslate, Translation
+from klingon.models import CanNotTranslate, Translatable, Translation
 
 from .testapp.models import Book, Library
 
@@ -182,4 +182,59 @@ class UnsavedInstanceGuardTestCase(TestCase):
             CanNotTranslate,
             book.set_translation,
             'es', 'title', 'x',
+        )
+
+    def test_get_translation_obj_create_raises_for_unsaved_instance(self):
+        book = Book()
+
+        self.assertRaises(
+            CanNotTranslate,
+            book.get_translation_obj,
+            'es', 'title', True,
+        )
+
+    def test_get_translation_no_cache_bleed_between_unsaved_instances(self):
+        book_a = Book(title='Alpha')
+        book_b = Book(title='Beta')
+
+        self.assertEqual(book_a.get_translation('es', 'title'), 'Alpha')
+        self.assertEqual(book_b.get_translation('es', 'title'), 'Beta')
+        # calling again (order reversed) must still be instance-specific
+        self.assertEqual(book_b.get_translation('es', 'title'), 'Beta')
+        self.assertEqual(book_a.get_translation('es', 'title'), 'Alpha')
+
+        self.assertEqual(Translation.objects.count(), 0)
+
+    def test_translations_no_cache_bleed_between_unsaved_instances(self):
+        book_a = Book(title='Alpha')
+        book_b = Book(title='Beta')
+
+        self.assertEqual(book_a.translations('es')['title'], 'Alpha')
+        self.assertEqual(book_b.translations('es')['title'], 'Beta')
+
+        self.assertEqual(Translation.objects.count(), 0)
+
+
+class AllTranslatableFieldsMutationTestCase(TestCase):
+    """
+    Bug: _all_translatable_fields() aliased a list-typed translatable_fields
+    class attribute and mutated it in place via `+=`.
+    """
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_list_translatable_fields_not_mutated(self):
+        class LocalTranslatable(Translatable):
+            translatable_fields = ['title', 'description']
+            translatable_slug = 'slug'
+
+        instance = LocalTranslatable()
+
+        instance._all_translatable_fields()
+        instance._all_translatable_fields()
+
+        self.assertEqual(
+            LocalTranslatable.translatable_fields,
+            ['title', 'description'],
         )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -67,3 +67,15 @@ class ExplicitSlugTranslationTestCase(TestCase):
         self.library.set_translation('es', 'slug', 'mi-slug-custom')
         db_value = Translation.objects.get(lang='es', field='slug').translation
         self.assertEqual(self.library.get_translation('es', 'slug'), db_value)
+
+    def test_explicit_slug_survives_unrelated_field_translation(self):
+        # Bug: the old gate regenerated the slug whenever the field being
+        # set was merely "not the slug", so translating an unrelated field
+        # (description, which is not the slug's source field) clobbered an
+        # explicit slug override.
+        self.library.set_translation('es', 'slug', 'mi-slug-custom')
+        self.library.set_translation('es', 'description', 'Todo en ebooks')
+
+        db_value = Translation.objects.get(lang='es', field='slug').translation
+        self.assertEqual(db_value, 'mi-slug-custom')
+        self.assertEqual(self.library.get_translation('es', 'slug'), db_value)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,81 +1,66 @@
 """
 Regression tests for cache/auto-slug bugs found in the 0.1.0 revival review.
 """
-from django.core.cache import cache
-from django.test import TestCase
+import pytest
 
 from klingon.models import Translation
 
-from .testapp.models import Library
 
-
-class SlugCacheInvalidationTestCase(TestCase):
+@pytest.mark.django_db
+def test_slug_cache_refreshed_after_source_field_translation(library):
     """
     Bug 1: set_translation() on the slug's source field regenerated the slug
     Translation row but never refreshed the slug's per-field cache key, so
     get_translation() kept serving the stale pre-translation value.
     """
+    # Prime the per-field cache with the fallback (English) slug
+    assert library.get_translation('es', 'slug') == 'independent'
 
-    def setUp(self):
-        self.library = Library.objects.create(
-            name="Independent",
-            description="All in ebooks",
-        )
+    # Translating the source field regenerates the slug translation
+    library.set_translation('es', 'name', 'Independiente')
+    db_value = Translation.objects.get(lang='es', field='slug').translation
+    assert db_value == 'independiente'
 
-    def tearDown(self):
-        cache.clear()
-
-    def test_slug_cache_refreshed_after_source_field_translation(self):
-        # Prime the per-field cache with the fallback (English) slug
-        self.assertEqual(
-            self.library.get_translation('es', 'slug'),
-            'independent',
-        )
-        # Translating the source field regenerates the slug translation
-        self.library.set_translation('es', 'name', 'Independiente')
-        db_value = Translation.objects.get(lang='es', field='slug').translation
-        self.assertEqual(db_value, 'independiente')
-        # The API must agree with the database, not the stale cache
-        self.assertEqual(self.library.get_translation('es', 'slug'), db_value)
+    # The API must agree with the database, not the stale cache
+    assert library.get_translation('es', 'slug') == db_value
 
 
-class ExplicitSlugTranslationTestCase(TestCase):
+@pytest.mark.django_db
+def test_explicit_slug_translation_is_kept(library):
     """
     Bug 2: set_translation() on the slug field itself saved the given text,
     then the auto-slug block immediately overwrote the same row with
     slugify(<title_field translation>) — losing the explicit value and
     leaving the cache disagreeing with the database.
     """
+    library.set_translation('es', 'name', 'Independiente')
+    library.set_translation('es', 'slug', 'mi-slug-custom')
+    db_value = Translation.objects.get(lang='es', field='slug').translation
+    assert db_value == 'mi-slug-custom'
 
-    def setUp(self):
-        self.library = Library.objects.create(
-            name="Independent",
-            description="All in ebooks",
-        )
 
-    def tearDown(self):
-        cache.clear()
+@pytest.mark.django_db
+def test_explicit_slug_translation_cache_matches_db(library):
+    """
+    Verify that explicit slug translations stay in sync between cache and database.
+    """
+    library.set_translation('es', 'name', 'Independiente')
+    library.set_translation('es', 'slug', 'mi-slug-custom')
+    db_value = Translation.objects.get(lang='es', field='slug').translation
+    assert library.get_translation('es', 'slug') == db_value
 
-    def test_explicit_slug_translation_is_kept(self):
-        self.library.set_translation('es', 'name', 'Independiente')
-        self.library.set_translation('es', 'slug', 'mi-slug-custom')
-        db_value = Translation.objects.get(lang='es', field='slug').translation
-        self.assertEqual(db_value, 'mi-slug-custom')
 
-    def test_explicit_slug_translation_cache_matches_db(self):
-        self.library.set_translation('es', 'name', 'Independiente')
-        self.library.set_translation('es', 'slug', 'mi-slug-custom')
-        db_value = Translation.objects.get(lang='es', field='slug').translation
-        self.assertEqual(self.library.get_translation('es', 'slug'), db_value)
+@pytest.mark.django_db
+def test_explicit_slug_survives_unrelated_field_translation(library):
+    """
+    Bug: the old gate regenerated the slug whenever the field being
+    set was merely "not the slug", so translating an unrelated field
+    (description, which is not the slug's source field) clobbered an
+    explicit slug override.
+    """
+    library.set_translation('es', 'slug', 'mi-slug-custom')
+    library.set_translation('es', 'description', 'Todo en ebooks')
 
-    def test_explicit_slug_survives_unrelated_field_translation(self):
-        # Bug: the old gate regenerated the slug whenever the field being
-        # set was merely "not the slug", so translating an unrelated field
-        # (description, which is not the slug's source field) clobbered an
-        # explicit slug override.
-        self.library.set_translation('es', 'slug', 'mi-slug-custom')
-        self.library.set_translation('es', 'description', 'Todo en ebooks')
-
-        db_value = Translation.objects.get(lang='es', field='slug').translation
-        self.assertEqual(db_value, 'mi-slug-custom')
-        self.assertEqual(self.library.get_translation('es', 'slug'), db_value)
+    db_value = Translation.objects.get(lang='es', field='slug').translation
+    assert db_value == 'mi-slug-custom'
+    assert library.get_translation('es', 'slug') == db_value


### PR DESCRIPTION
## Summary

- Fix cache/slug edge cases found in code review: slug translations no longer get clobbered by unrelated field updates, unsaved instances no longer leak cache values between each other, unsaved-instance errors are now `CanNotTranslate` instead of raw `IntegrityError`, and `translatable_fields` as a `list` is no longer mutated in place.
- Make CI's coverage gate fail visibly instead of hiding inside XML generation; `make coverage` no longer aborts before generating the HTML report.
- Migrate the test suite (45 tests) from `unittest.TestCase` to pytest-native functions and fixtures, cutting ~15 duplicated setUp/tearDown blocks.
- Ignore `uv.lock` — this is a library tested across a Django/Python matrix, so a single locked resolution isn't representative.

## Test plan

- [x] `pytest tests/ -v` — 45/45 passing
- [x] `pytest tests/ --cov=klingon` — 100% coverage
- [x] `ruff check klingon tests` — clean
- [x] Verified against Django 4.2, 5.2, 6.0
